### PR TITLE
Player count in dashboard.js fix

### DIFF
--- a/static/js/pages/admin/dashboard.js
+++ b/static/js/pages/admin/dashboard.js
@@ -13,7 +13,7 @@ new Vue({
     methods: {
         GetOnlineUsers() {
             var vm = this;
-            vm.$axios.get(window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + "/api/get_online")
+            vm.$axios.get(window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + "/api/get_player_count")
                 .then(function (response) {
                     vm.online_users = response.data.online;
                 });


### PR DESCRIPTION
Api request was sent to wrong address, i fixed it.

**Note!** There is subdomain bug which sends api request to subdomain`.domain` and as we know gulag web on osu subdomain is blocking api requests (I dunno why) and any other subdomain will route api request to subdomain.domain. So it needs fix, I did it by simply adding `.replace('www', 'osu')` but thats not the best solution as everything matching www is replaced + not everyone uses www subdomain.
